### PR TITLE
Add vl-convert-python for altair dependency

### DIFF
--- a/pythonRequirements.txt
+++ b/pythonRequirements.txt
@@ -4,3 +4,4 @@ pandas
 altair
 altair_saver
 altair_viewer
+vl-convert-python


### PR DESCRIPTION
Saving charts in 'png' format requires the vl-convert-python package